### PR TITLE
null metadata key issue when converting from an exception

### DIFF
--- a/src/Result.Net/Result.Extensions.cs
+++ b/src/Result.Net/Result.Extensions.cs
@@ -193,8 +193,13 @@
                 .WithErrors(exception.InnerException);
 
             if (exception.Data.Count > 0)
+            {
                 foreach (var key in exception.Data.Keys)
-                    result.WithMataData(key as string, exception.Data[key]);
+                {
+                    if (key is string keyValue)
+                        result.WithMataData(keyValue, exception.Data[key]);
+                }
+            }
 
             return result;
         }

--- a/tests/Result.Net.Tests/Result.Net.Tests.csproj
+++ b/tests/Result.Net.Tests/Result.Net.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
added a check when mapping the data of an exception to the metadata list in the Result object the data key must be a string.