### PR TITLE
Extend ResultError with Exception type, and add Matching functionality

### DIFF
--- a/src/Result.Net/Result.Extensions.cs
+++ b/src/Result.Net/Result.Extensions.cs
@@ -174,6 +174,50 @@
         }
 
         /// <summary>
+        /// run the given action base on result if success or failure
+        /// </summary>
+        /// <typeparam name="TResult">the type of the result</typeparam>
+        /// <param name="result">the result instance</param>
+        /// <param name="onSuccess">the action to run on success</param>
+        /// <param name="onFailure">the action to run on failure</param>
+        public static void Match<TResult>(this TResult result, Action<TResult> onSuccess, Action<TResult> onFailure)
+            where TResult : Result
+        {
+            if (result.IsFailure())
+            {
+                onFailure?.Invoke(result);
+                return;
+            }
+
+            onSuccess?.Invoke(result);
+        }
+
+        /// <summary>
+        /// match the result status and run the function accordingly.
+        /// </summary>
+        /// <typeparam name="TResult">the type of the result</typeparam>
+        /// <param name="result">the result instance</param>
+        /// <param name="onSuccess">the action to run on success</param>
+        /// <param name="onFailure">the action to run on failure</param>
+        /// <returns>the output </returns>
+        public static TOut Match<TResult, TOut>(this TResult result, Func<TResult, TOut> onSuccess, Func<TResult, TOut> onFailure)
+            where TResult : Result
+        {
+            if (result.IsFailure())
+            {
+                if (onFailure is null)
+                    return default;
+
+                return onFailure(result);
+            }
+
+            if (onSuccess is null)
+                return default;
+
+            return onSuccess(result);
+        }
+
+        /// <summary>
         /// check if the given list empty
         /// </summary>
         public static bool IsListEmpty<TData>(this ListResult<TData> result) => result.Count <= 0;

--- a/src/Result.Net/Result.Extensions.cs
+++ b/src/Result.Net/Result.Extensions.cs
@@ -47,18 +47,35 @@
         }
 
         /// <summary>
-        /// set the log trace Code related to this result instance
+        /// add a result error to the list of errors
         /// </summary>
         /// <param name="result">the result object instance</param>
-        /// <param name="errors">the trace Code data</param>
+        /// <param name="message">the error message</param>
+        /// <param name="code">the error code</param>
         /// <returns>the current instance to enable method chaining</returns>
-        public static TResult WithErrors<TResult>(this TResult result, params ResultError[] errors) where TResult : Result
-        {
-            foreach (var error in errors)
-            {
-                result.Errors.Add(error);
-            }
+        public static TResult WithError<TResult>(this TResult result, string message, string code) where TResult : Result
+            => WithError(result, new ResultError(message, code));
 
+        /// <summary>
+        /// add a result error to the list of errors
+        /// </summary>
+        /// <param name="result">the result object instance</param>
+        /// <param name="message">the error message</param>
+        /// <param name="code">the error code</param>
+        /// <param name="source">the error source</param>
+        /// <returns>the current instance to enable method chaining</returns>
+        public static TResult WithError<TResult>(this TResult result, string message, string code, string source) where TResult : Result
+            => WithError(result, new ResultError(message, code, source));
+
+        /// <summary>
+        /// add a result error to the list of errors
+        /// </summary>
+        /// <param name="result">the result object instance</param>
+        /// <param name="error">the error instance</param>
+        /// <returns>the current instance to enable method chaining</returns>
+        public static TResult WithError<TResult>(this TResult result, ResultError error) where TResult : Result
+        {
+            result.Errors.Add(error);
             return result;
         }
 
@@ -68,12 +85,25 @@
         /// <param name="result">the result object instance</param>
         /// <param name="exception">the exception instance</param>
         /// <returns>the current instance to enable method chaining</returns>
-        public static TResult WithErrors<TResult>(this TResult result, Exception exception) where TResult : Result
+        public static TResult WithError<TResult>(this TResult result, Exception exception) where TResult : Result
         {
-            foreach (var error in ResultError.GetFromException(exception))
-            {
+            if (exception is null)
+                return result;
+
+            result.Errors.Add(new ResultError(exception));
+            return result;
+        }
+
+        /// <summary>
+        /// add a result error to the list of errors
+        /// </summary>
+        /// <param name="result">the result object instance</param>
+        /// <param name="errors">the errors</param>
+        /// <returns>the current instance to enable method chaining</returns>
+        public static TResult WithErrors<TResult>(this TResult result, params ResultError[] errors) where TResult : Result
+        {
+            foreach (var error in errors)
                 result.Errors.Add(error);
-            }
 
             return result;
         }
@@ -190,7 +220,7 @@
             var result = Result.Failure()
                 .WithMessage(exception.Message)
                 .WithCode(ResultCode.OperationFailedException)
-                .WithErrors(exception.InnerException);
+                .WithError(exception.InnerException);
 
             if (exception.Data.Count > 0)
             {

--- a/src/Result.Net/ResultObjects/Result.cs
+++ b/src/Result.Net/ResultObjects/Result.cs
@@ -90,7 +90,6 @@
             {
                 Code = ResultCode.OperationFailed;
                 LogTraceCode = Utilities.GenerateLogTraceErrorCode();
-                return;
             }
         }
 

--- a/tests/Result.Net.Tests/FailedResultShould.cs
+++ b/tests/Result.Net.Tests/FailedResultShould.cs
@@ -78,8 +78,8 @@
             var result = Result.Failure()
                 .WithErrors(new[]
                 {
-                    new ResultError("test", "test_code", "source", "errorType"),
-                    new ResultError("test", "test_code", "source", "errorType")
+                    new ResultError("test", "test_code", "source"),
+                    new ResultError("test", "test_code", "source")
                 });
 
             // assert
@@ -95,7 +95,7 @@
 
             // act
             var result = Result.Failure()
-                .WithErrors(new Exception("exception message"));
+                .WithError(new Exception("exception message"));
 
             // assert
             Assert.Equal(expectedErrorsCount, result.Errors.Count);

--- a/tests/Result.Net.Tests/ResultErrorShould.cs
+++ b/tests/Result.Net.Tests/ResultErrorShould.cs
@@ -15,11 +15,11 @@
             var exception = new Exception("test exception");
 
             // act
-            ResultError error = ResultError.MapFromException(exception);
+            ResultError error = new ResultError(exception);
 
             // assert
             Assert.Equal("test exception", error.Message);
-            Assert.Equal("Exception", error.Type);
+            Assert.Equal(exception.Source, error.Source);
             Assert.Equal(ResultCode.OperationFailedException, error.Code);
         }
     }

--- a/tests/Result.Net.Tests/ResultExtensionsShould.cs
+++ b/tests/Result.Net.Tests/ResultExtensionsShould.cs
@@ -1,0 +1,139 @@
+﻿namespace ResultNet.Tests
+{
+    using Xunit;
+
+    public class ResultExtensionsShould
+    {
+        [Fact]
+        public void Match_Result_On_Success()
+        {
+            // arrange
+            var result = Result.Success();
+            var expected = "run";
+
+            // act
+            var outPut = string.Empty;
+
+            result.Match(
+                onSuccess: result => outPut = "run",
+                onFailure: result => outPut = "run1");
+
+            // assert
+            Assert.Equal(expected, outPut);
+        }
+
+        [Fact]
+        public void Not_Match_Result_On_Success_When_Action_Null()
+        {
+            // arrange
+            var result = Result.Success();
+
+            // act
+            var outPut = string.Empty;
+
+            result.Match(
+                onSuccess: null,
+                onFailure: result => outPut = "run1");
+
+            // assert
+            Assert.Empty(outPut);
+        }
+
+        [Fact]
+        public void Match_Result_On_Failure()
+        {
+            // arrange
+            var result = Result.Failure();
+            var expected = "run";
+
+            // act
+            var outPut = string.Empty;
+
+            result.Match(
+                onSuccess: result => outPut = "run1",
+                onFailure: result => outPut = "run");
+
+            // assert
+            Assert.Equal(expected, outPut);
+        }
+        
+        [Fact]
+        public void Not_Match_Result_On_Failure_When_Action_Null()
+        {
+            // arrange
+            var result = Result.Failure();
+
+            // act
+            var outPut = string.Empty;
+
+            result.Match(
+                onSuccess: result => outPut = "run1",
+                onFailure: null);
+
+            // assert
+            Assert.Empty(outPut);
+        }
+
+        [Fact]
+        public void Match_Result_On_Success_And_Return_Output()
+        {
+            // arrange
+            var result = Result.Success();
+            var expected = "run";
+
+            // act
+            var outPut = result.Match(
+                onSuccess: result => "run",
+                onFailure: result => "run1");
+
+            // assert
+            Assert.Equal(expected, outPut);
+        }
+
+        [Fact]
+        public void Match_Result_On_Failure_And_Return_Output()
+        {
+            // arrange
+            var result = Result.Failure();
+            var expected = "run";
+
+            // act
+            var outPut = result.Match(
+                onSuccess: result => "run1",
+                onFailure: result => "run");
+
+            // assert
+            Assert.Equal(expected, outPut);
+        }
+
+        [Fact]
+        public void Match_Result_On_Success_And_Return_Default_When_Null()
+        {
+            // arrange
+            var result = Result.Success();
+
+            // act
+            var outPut = result.Match(
+                onSuccess: null,
+                onFailure: result => "run1");
+
+            // assert
+            Assert.Equal(default, outPut);
+        }
+
+        [Fact]
+        public void Match_Result_On_Failure_And_Return_Default_When_Null()
+        {
+            // arrange
+            var result = Result.Failure();
+
+            // act
+            var outPut = result.Match(
+                onSuccess: result => "run1",
+                onFailure: null);
+
+            // assert
+            Assert.Equal(default, outPut);
+        }
+    }
+}


### PR DESCRIPTION
Extend the ResultError object with a property that holds the exception related to the result. and removed the Type property because it is not relevant now we have the exception directly embedded in the ResultError object, and we have the Code property which is more expressive.

Added a new extension method on the Result object to allow the matching of the result status in a more fluent syntax
```csharp
var result = Result.Success();

result.Match(
      onSuccess: result => { Console.WriteLine("executed if result has a success status"); },
      onFailure: result => { Console.WriteLine("executed if result has a failure status"); });
```

you can also return an output
```csharp
var output = result.Match(
      onSuccess: result => { 
            Console.WriteLine("executed if result has a success status"); 
            return "test";
      },
      onFailure: result => { 
            Console.WriteLine("executed if result has a failure status"); 
            return "test";
      });
```